### PR TITLE
synced up versions with the apollo versions

### DIFF
--- a/apollo/data/MGI/trackList.json
+++ b/apollo/data/MGI/trackList.json
@@ -52,7 +52,7 @@
          "key" : "All Genes",
          "storeClass" : "JBrowse/Store/SeqFeature/NCList",
          "trackType" : "CanvasFeatures",
-         "urlTemplate" : "https://s3.amazonaws.com/agrjbrowse/docker/3.2.0/MGI/mouse/tracks/All%20Genes/{refseq}/trackData.jsonz",
+         "urlTemplate" : "https://s3.amazonaws.com/agrjbrowse/docker/4.0.0/MGI/mouse/tracks/All%20Genes/{refseq}/trackData.jsonz",
          "compress" : 1,
          "type" : "CanvasFeatures",
          "label" : "All Genes",

--- a/apollo/data/RGD/trackList.json
+++ b/apollo/data/RGD/trackList.json
@@ -60,7 +60,7 @@
          "key" : "All Genes",
          "storeClass" : "JBrowse/Store/SeqFeature/NCList",
          "trackType" : "JBrowse/View/Track/CanvasFeatures",
-         "urlTemplate" : "https://s3.amazonaws.com/agrjbrowse/docker/3.2.0/RGD/rat/tracks/All%20Genes/{refseq}/trackData.jsonz",
+         "urlTemplate" : "https://s3.amazonaws.com/agrjbrowse/docker/4.0.0/RGD/rat/tracks/All%20Genes/{refseq}/trackData.jsonz",
          "compress" : 1,
          "type" : "CanvasFeatures",
          "label" : "All Genes",

--- a/apollo/data/fly/trackList.json
+++ b/apollo/data/fly/trackList.json
@@ -59,7 +59,7 @@
          "key" : "All Genes",
          "storeClass" : "JBrowse/Store/SeqFeature/NCList",
          "trackType" : "CanvasFeatures",
-         "urlTemplate" : "https://s3.amazonaws.com/agrjbrowse/docker/3.2.0/FlyBase/fruitfly/tracks/All Genes/{refseq}/trackData.jsonz",
+         "urlTemplate" : "https://s3.amazonaws.com/agrjbrowse/docker/4.0.0/FlyBase/fruitfly/tracks/All Genes/{refseq}/trackData.jsonz",
          "compress" : 1,
          "type" : "CanvasFeatures",
          "label" : "All Genes",

--- a/apollo/data/worm/trackList.json
+++ b/apollo/data/worm/trackList.json
@@ -34,7 +34,7 @@
             "className" : "feature"
          },
          "compress" : 1,
-         "urlTemplate" : "https://s3.amazonaws.com/agrjbrowse/docker/3.2.0/WormBase/c_elegans_PRJNA13758/tracks/All Genes/{refseq}/trackData.jsonz",
+         "urlTemplate" : "https://s3.amazonaws.com/agrjbrowse/docker/4.0.0/WormBase/c_elegans_PRJNA13758/tracks/All Genes/{refseq}/trackData.jsonz",
          "type" : "CanvasFeatures",
          "key" : "All Genes"
       },

--- a/apollo/data/yeast/trackList.json
+++ b/apollo/data/yeast/trackList.json
@@ -46,7 +46,7 @@
          "key" : "All Genes",
          "maxHeight" : 3000,
          "compress" : 1,
-         "urlTemplate" : "https://s3.amazonaws.com/agrjbrowse/docker/3.2.0/SGD/yeast/tracks/All Genes/{refseq}/trackData.jsonz",
+         "urlTemplate" : "https://s3.amazonaws.com/agrjbrowse/docker/4.0.0/SGD/yeast/tracks/All Genes/{refseq}/trackData.jsonz",
          "fmtDetailValue_Name" : "function(name, feature) {if(feature.get('type')=='gene') {return '<a href=\"http://www.yeastgenome.org/locus/'+name+'/overview\">'+name+'</a>';} else { return name;}}"
       },
       {

--- a/apollo/data/zebrafish/trackList.json
+++ b/apollo/data/zebrafish/trackList.json
@@ -34,7 +34,7 @@
          "key" : "All Genes",
          "storeClass" : "JBrowse/Store/SeqFeature/NCList",
          "trackType" : "CanvasFeatures",
-         "urlTemplate" : "https://s3.amazonaws.com/agrjbrowse/docker/3.2.0/zfin/zebrafish-11/tracks/All Genes/{refseq}/trackData.jsonz",
+         "urlTemplate" : "https://s3.amazonaws.com/agrjbrowse/docker/4.0.0/zfin/zebrafish-11/tracks/All Genes/{refseq}/trackData.jsonz",
          "compress" : 1,
          "type" : "CanvasFeatures",
          "label" : "All Genes",


### PR DESCRIPTION
Fixes this:

https://github.com/GMOD/Apollo/issues/2582

On build, this is:

![image](https://user-images.githubusercontent.com/751274/108735921-eef07180-74e5-11eb-8500-b55d4c18ac44.png)

However, even with these changes I get:

![image](https://user-images.githubusercontent.com/751274/108735992-04fe3200-74e6-11eb-9fb8-d90556ac55dd.png)


However, it is possible that we don't see them because they are all lnc_RNA . . . 